### PR TITLE
Modernize dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .cache
-.coverage
+.coverage*
 .installed.cfg
 .tox
 .venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
           env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
-          dist: xenial
+        - python: 3.8
+          env: TOXENV=py38
 install:
   - pip install tox-travis coveralls
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ CHANGELOG
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python-3.8
+
+- Drop support for Python-2.7
+
+- Modernize development environment with pipenv
 
 
 1.3.1 (2019-03-01)

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+pytest-coverage = "*"
+mock = "*"
+
+[packages]
+migrant = {editable = true,path = "."}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,154 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "85756607d299bfa0ecc0ffba19e0783ca40d310007ff2abbc9b139d93828bd10"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "migrant": {
+            "editable": true,
+            "path": "."
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
+                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
+                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
+                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
+                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
+                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
+                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
+                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
+                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
+                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
+                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
+                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
+                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
+                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
+                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
+                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
+                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
+                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
+                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
+                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
+                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
+                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
+                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
+                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
+                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
+                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
+                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
+                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
+                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
+                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
+                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+            ],
+            "version": "==5.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0",
+                "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
+                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+            ],
+            "version": "==2.8.1"
+        },
+        "pytest-cover": {
+            "hashes": [
+                "sha256:578249955eb3b5f3991209df6e532bb770b647743b7392d3d97698dc02f39ebb",
+                "sha256:5bdb6c1cc3dd75583bb7bc2c57f5e1034a1bfcb79d27c71aceb0b16af981dbf4"
+            ],
+            "version": "==3.0.0"
+        },
+        "pytest-coverage": {
+            "hashes": [
+                "sha256:db6af2cbd7e458c7c9fd2b4207cee75258243c8a81cad31a7ee8cfad5be93c05",
+                "sha256:dedd084c5e74d8e669355325916dc011539b190355021b037242514dee546368"
+            ],
+            "index": "pypi",
+            "version": "==0.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
+                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+            ],
+            "version": "==0.1.9"
+        }
+    }
+}

--- a/README.rst
+++ b/README.rst
@@ -27,3 +27,19 @@ Features include:
   * support for downgrading
   * support for out-of-order migrations
   * support for migrating multiple homogenuous databases
+
+
+Development
+-----------
+
+To set up development environment, use `pipenv`::
+
+    pipenv install --dev
+
+To run tests, use `pytest`::
+
+    pytest
+
+To run tests under all supported environments, use `tox`::
+
+    tox --skip-missing-interpreters

--- a/src/migrant/cli.py
+++ b/src/migrant/cli.py
@@ -7,7 +7,7 @@ import os
 import sys
 import argparse
 import logging
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 from migrant import exceptions
 from migrant.engine import MigrantEngine
@@ -122,9 +122,9 @@ test_parser.add_argument(
 def load_config(fname):
     if not os.path.exists(fname):
         raise exceptions.ConfigurationError("%s is missing" % fname)
-    cfg = SafeConfigParser()
+    cfg = ConfigParser()
     with open(fname) as cfgfp:
-        cfg.readfp(cfgfp)
+        cfg.read_file(cfgfp)
     return cfg
 
 

--- a/src/migrant/repository.py
+++ b/src/migrant/repository.py
@@ -4,10 +4,10 @@
 #
 ###############################################################################
 import os
-import imp
 import logging
 import string
 import hashlib
+from importlib.machinery import SourceFileLoader
 
 try:
     from string import maketrans
@@ -65,7 +65,7 @@ class Script:
     def __init__(self, filename):
         assert filename.endswith(".py")
         self.name = os.path.basename(filename)[:-3]
-        self.module = imp.load_source(self.name, filename)
+        self.module = SourceFileLoader(self.name, filename).load_module()
 
     def up(self, db):
         self._exec("up", db)

--- a/src/migrant/tests/test_cli.py
+++ b/src/migrant/tests/test_cli.py
@@ -11,7 +11,7 @@ import shutil
 import textwrap
 import logging
 import pytest
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 import multiprocessing
 
 from migrant import cli, backend, exceptions
@@ -90,8 +90,8 @@ class MockedBackend(backend.MigrantBackend):
 
 class ConfigTest(unittest.TestCase):
     def test_get_db_config(self):
-        cp = SafeConfigParser()
-        cp.readfp(io.StringIO(SAMPLE_CONFIG), "SAMPLE_CONFIG")
+        cp = ConfigParser()
+        cp.read_file(io.StringIO(SAMPLE_CONFIG), "SAMPLE_CONFIG")
         config = cli.get_db_config(cp, "db1")
         self.assertEqual(
             config,
@@ -245,8 +245,8 @@ def sample_config(tmpdir):
         % tmpdir
     )
 
-    cfg = SafeConfigParser()
-    cfg.readfp(io.StringIO(SAMPLE_CONFIG), "SAMPLE_CONFIG")
+    cfg = ConfigParser()
+    cfg.read_file(io.StringIO(SAMPLE_CONFIG), "SAMPLE_CONFIG")
     return cfg
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37
+envlist = py36, py37, py38
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
* Introduce pipenv to manage dev environment
* Remove support for py 2.7, add support for 3.8
* Get rid of deprecation warnings
* Convert Readme to markdown format
